### PR TITLE
feat(CK Board): Make changes to support SCORE and CK Board SSO

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     command: mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005" -Dspring-boot.run.profiles=dockerdev
 
   score-client:
-    image: wiseberkeley/wise-client-dev:v5
+    image: wiseberkeley/wise-client-dev:latest
     container_name: score-client
     depends_on:
       - score-api
@@ -41,7 +41,6 @@ services:
       - '4200:4200'
     volumes:
       - '../SCORE-Client:/app'
-      - '/app/node_modules/'
 
   score-nginx:
     image: nginx:1.13
@@ -49,6 +48,6 @@ services:
     depends_on:
       - score-client
     ports:
-      - '81:80'
+      - '80:80'
     volumes:
       - '${PWD}/nginx/conf.d:/etc/nginx/conf.d'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - './data:/var/lib/mysql'
 
   score-api:
-    image: wiseberkeley/wise-api-dev:v1
+    image: wiseberkeley/wise-api-dev:latest
     container_name: score-api
     expose:
       - '5005'

--- a/nginx/conf.d/wise.conf
+++ b/nginx/conf.d/wise.conf
@@ -94,6 +94,20 @@ proxy_set_header X-Forwarded-Host $server_name;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+    location /sso/discourse {
+proxy_pass http://score-api:8080;
+proxy_set_header Host $host:$server_port;
+proxy_set_header X-Forwarded-Host $server_name;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+    location /sso/ckboard {
+proxy_pass http://score-api:8080;
+proxy_set_header Host $host:$server_port;
+proxy_set_header X-Forwarded-Host $server_name;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
     rewrite ^/wise5/(.*)$ /assets/wise5/$1 last;
 


### PR DESCRIPTION
Note: Make sure to change port number in application-dockerdev.properties in SCORE-API from 81 to 80 like this below

```
wise.hostname=http://localhost:80
wise4.hostname=http://localhost:80/legacy

google.redirectUri=http://localhost:80/api/google-login
```

## Changes

- Changed SCORE frontend port from 81 to 80
- Added Nginx route for the new /sso/ckboard endpoint

## Test

Make sure SCORE is accessible on http://localhost instead of http://localhost:81